### PR TITLE
Update Shopping flux SERVICE_URL

### DIFF
--- a/API/AbstractWebService.php
+++ b/API/AbstractWebService.php
@@ -25,7 +25,7 @@ abstract class AbstractWebService
     /**
      * This is the webservice url.
      */
-    const SERVICE_URL = 'https://clients.shopping-flux.com/webservice/';
+    const SERVICE_URL = 'https://ws.shopping-flux.com/';
 
     const REQUEST_MODE_SANDBOX = "Sandbox";
 


### PR DESCRIPTION
Hi everybody, great job for the module!
Just a small fix, even https://clients.shopping-flux.com/webservice/ works (but will be deprecated), https://ws.shopping-flux.com/ is the direct link to our webservice. There's nothing to expect, as the old url just make a call to the new one. Answers are just faster
